### PR TITLE
Merge into shulker on manual sort

### DIFF
--- a/src/main/java/de/jeff_media/ChestSort/ChestSortListener.java
+++ b/src/main/java/de/jeff_media/ChestSort/ChestSortListener.java
@@ -19,6 +19,7 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.inventory.InventoryType.SlotType;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 
@@ -391,13 +392,17 @@ public class ChestSortListener implements Listener {
                 return;
             }
 
+
+
             if (LlamaUtils.belongsToLlama(event.getClickedInventory())) {
                 ChestedHorse llama = (ChestedHorse) event.getInventory().getHolder();
+                plugin.organizer.condenseIntoShulkers(event.getClickedInventory(), 2, LlamaUtils.getLlamaChestSize(llama) + 1);
                 plugin.organizer.sortInventory(event.getClickedInventory(), 2, LlamaUtils.getLlamaChestSize(llama) + 1);
                 plugin.organizer.updateInventoryView(event);
                 return;
             }
 
+            plugin.organizer.condenseIntoShulkers(event.getClickedInventory());
             plugin.organizer.sortInventory(event.getClickedInventory());
             plugin.organizer.updateInventoryView(event);
         } else if (holder instanceof Player) {
@@ -406,9 +411,15 @@ public class ChestSortListener implements Listener {
             }
 
             if (event.getSlotType() == SlotType.QUICKBAR) {
+                plugin.organizer.condenseIntoShulkers(event.getClickedInventory(), 0, 8);
                 plugin.organizer.sortInventory(p.getInventory(), 0, 8);
                 plugin.organizer.updateInventoryView(event);
             } else if (event.getSlotType() == SlotType.CONTAINER) {
+                // prevent item loss from shulker packs - this may warrant a message (e.g. "closed shulker pack while sorting to prevent item loss")
+                if(p.getOpenInventory().getTitle().toUpperCase().contains("SHULKER PACK")) {
+                    p.closeInventory();
+                }
+                plugin.organizer.condenseIntoShulkers(event.getClickedInventory(), 9, 35);
                 plugin.organizer.sortInventory(p.getInventory(), 9, 35);
                 plugin.organizer.updateInventoryView(event);
             }

--- a/src/main/java/de/jeff_media/ChestSort/ChestSortListener.java
+++ b/src/main/java/de/jeff_media/ChestSort/ChestSortListener.java
@@ -392,8 +392,6 @@ public class ChestSortListener implements Listener {
                 return;
             }
 
-
-
             if (LlamaUtils.belongsToLlama(event.getClickedInventory())) {
                 ChestedHorse llama = (ChestedHorse) event.getInventory().getHolder();
                 plugin.organizer.condenseIntoShulkers(event.getClickedInventory(), 2, LlamaUtils.getLlamaChestSize(llama) + 1);

--- a/src/main/java/de/jeff_media/ChestSort/ChestSortOrganizer.java
+++ b/src/main/java/de/jeff_media/ChestSort/ChestSortOrganizer.java
@@ -661,33 +661,4 @@ public class ChestSortOrganizer {
             }
         }
     }
-
-    public void condenseIntoShulkers(InventoryView viewSource, int startSlot, int endSlot) {
-        Inventory source = viewSource.getBottomInventory();
-        Inventory openShulker = viewSource.getTopInventory();
-        for(int i = startSlot; i <= endSlot; i++) {
-            ItemStack sourceStack = source.getItem(i);
-            if(sourceStack == null) continue;
-
-            // check if item is a Shulker Box
-            if(sourceStack.getItemMeta() instanceof BlockStateMeta) {
-                BlockStateMeta im = (BlockStateMeta)sourceStack.getItemMeta();
-                if(im.getBlockState() instanceof ShulkerBox) {
-                    // found a Shulker Box
-                    ShulkerBox sourceShulker = (ShulkerBox) im.getBlockState();
-                    Inventory shulkerInv = sourceShulker.getInventory();
-                    //Inventory shulkerInv = Bukkit.createInventory(null,27,"SHULKER_BOX");
-                    //shulkerInv.setContents(sourceShulker.getInventory().getContents());
-
-                    // stuff Shulker Box
-                    stuffInventoryIntoAnother(source,shulkerInv,source,true);
-
-                    sourceShulker.getInventory().setContents(shulkerInv.getContents());
-                    im.setBlockState(sourceShulker);
-                    sourceStack.setItemMeta(im);
-                }
-            }
-        }
-    }
-
 }

--- a/src/main/java/de/jeff_media/ChestSort/ChestSortOrganizer.java
+++ b/src/main/java/de/jeff_media/ChestSort/ChestSortOrganizer.java
@@ -6,14 +6,17 @@ import de.jeff_media.ChestSort.utils.CategoryLinePair;
 import de.jeff_media.ChestSort.utils.TypeMatchPositionPair;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.block.ShulkerBox;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -627,6 +630,64 @@ public class ChestSortOrganizer {
             source.clear(i);
         }
         stuffInventoryIntoAnother(temp, destination, source, false);
+    }
+
+    public void condenseIntoShulkers(Inventory source) {
+        condenseIntoShulkers(source, 0, source.getSize() - 1);
+    }
+
+    public void condenseIntoShulkers(Inventory source, int startSlot, int endSlot) {
+
+        for(int i = startSlot; i <= endSlot; i++) {
+            ItemStack sourceStack = source.getItem(i);
+            if(sourceStack == null) continue;
+
+            // check if item is a Shulker Box
+            if(sourceStack.getItemMeta() instanceof BlockStateMeta) {
+                BlockStateMeta im = (BlockStateMeta)sourceStack.getItemMeta();
+                if(im.getBlockState() instanceof ShulkerBox) {
+                    // found a Shulker Box
+                    ShulkerBox sourceShulker = (ShulkerBox) im.getBlockState();
+                    Inventory shulkerInv = Bukkit.createInventory(null,27,"SHULKER_BOX");
+                    shulkerInv.setContents(sourceShulker.getInventory().getContents());
+
+                    // stuff Shulker Box
+                    stuffInventoryIntoAnother(source,shulkerInv,source,true);
+
+                    sourceShulker.getInventory().setContents(shulkerInv.getContents());
+                    im.setBlockState(sourceShulker);
+                    sourceStack.setItemMeta(im);
+                }
+            }
+        }
+    }
+
+    public void condenseIntoShulkers(InventoryView viewSource, int startSlot, int endSlot) {
+        Inventory source = viewSource.getBottomInventory();
+        Inventory openShulker = viewSource.getTopInventory();
+        for(int i = startSlot; i <= endSlot; i++) {
+            ItemStack sourceStack = source.getItem(i);
+            if(sourceStack == null) continue;
+
+            // check if item is a Shulker Box
+            if(sourceStack.getItemMeta() instanceof BlockStateMeta) {
+                BlockStateMeta im = (BlockStateMeta)sourceStack.getItemMeta();
+                if(im.getBlockState() instanceof ShulkerBox) {
+                    // found a Shulker Box
+                    ShulkerBox sourceShulker = (ShulkerBox) im.getBlockState();
+                    Inventory shulkerInv = sourceShulker.getInventory();
+                    //Inventory shulkerInv = Bukkit.createInventory(null,27,"SHULKER_BOX");
+                    //shulkerInv.setContents(sourceShulker.getInventory().getContents());
+
+                    // stuff Shulker Box
+                    stuffInventoryIntoAnother(source,shulkerInv,source,true);
+
+                    sourceShulker.getInventory().setContents(shulkerInv.getContents());
+                    im.setBlockState(sourceShulker);
+                    sourceStack.setItemMeta(im);
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Implemented the basic functionality for moving items in a sorted inventory into shulker boxes within that inventory when manually (hotkey) sorting.

Doing the same on autosorting using the condenseIntoShulkers function should be easy to implement if desired

Probably needs a permission node/check

Also, open to suggestions for better handling Shulker Packs if sorting player inventory while Shulker Pack is open - currently it just closes the inventory window, because if you don't, items added to or removed from Shulker Pack will be deleted/duplicated respectfully. Ideally, I think it would be nice to open the player's personal inventory window, but I'm yet to figure out how to do that from the server side.
