### PR TITLE
CoreProtect integration when using Fill/Empty chest hotkeys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <name>ChestSort</name>
     <url>https://www.chestsort.de</url>
     <description>Allows automatic chest sorting!</description>
-    <version>13.5.1</version>
+    <version>13.5.2</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -186,6 +186,11 @@
             <url>https://jitpack.io</url>
         </repository>
 
+        <repository>
+            <id>CoreProtect</id>
+            <url>https://maven.playpro.com/</url>
+        </repository>
+
     </repositories>
 
     <dependencies>
@@ -270,6 +275,13 @@
             <groupId>com.github.DeadSilenceIV</groupId>
             <artifactId>AdvancedChestsAPI</artifactId>
             <version>3.1-BETA</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.coreprotect</groupId>
+            <artifactId>coreprotect</artifactId>
+            <version>21.3</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/de/jeff_media/chestsort/hooks/CoreProtectHook.java
+++ b/src/main/java/de/jeff_media/chestsort/hooks/CoreProtectHook.java
@@ -1,0 +1,40 @@
+package de.jeff_media.chestsort.hooks;
+
+import net.coreprotect.CoreProtect;
+import net.coreprotect.CoreProtectAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.plugin.Plugin;
+
+public class CoreProtectHook {
+
+    public static void logContainerTransaction(String user, Location location) {
+        CoreProtectAPI api = getCoreProtect();
+        if (api == null) {
+            return;
+        }
+        api.logContainerTransaction(user, location);
+    }
+
+    private static CoreProtectAPI getCoreProtect() {
+        Plugin plugin = Bukkit.getServer().getPluginManager().getPlugin("CoreProtect");
+
+        // Check that CoreProtect is loaded
+        if (!(plugin instanceof CoreProtect)) {
+            return null;
+        }
+
+        // Check that the API is enabled
+        CoreProtectAPI api = ((CoreProtect) plugin).getAPI();
+        if (!api.isEnabled()) {
+            return null;
+        }
+
+        // Check that a compatible version of the API is loaded
+        if (api.APIVersion() < 9) {
+            return null;
+        }
+        return api;
+    }
+
+}

--- a/src/main/java/de/jeff_media/chestsort/listeners/ChestSortListener.java
+++ b/src/main/java/de/jeff_media/chestsort/listeners/ChestSortListener.java
@@ -31,10 +31,7 @@ import org.bukkit.event.inventory.InventoryType.SlotType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.InventoryHolder;
-import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.*;
 
 import java.util.HashMap;
 
@@ -732,6 +729,12 @@ public class ChestSortListener implements org.bukkit.event.Listener {
         Bukkit.getPluginManager().callEvent(chestSortEvent);
         if (chestSortEvent.isCancelled()) {
             return;
+        }
+
+        // CoreProtect hook
+        if (e.getInventory().getHolder() instanceof BlockInventoryHolder) {
+            Block block = ((BlockInventoryHolder) e.getInventory().getHolder()).getBlock();
+            CoreProtectHook.logContainerTransaction(p.getName(), block.getLocation());
         }
 
         if (e.isLeftClick() && setting.leftClick && p.hasPermission(Hotkey.getPermission(Hotkey.LEFT_CLICK))) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,7 +10,7 @@ website: ${project.url}
 prefix: ${spigot.prefix}
 database: false
 loadbefore: [InvUnload]
-softdepend: [CrackShot,InventoryPages,Minepacks,PlaceholderAPI,AdvancedChests,ShulkerPacks]
+softdepend: [CrackShot,InventoryPages,Minepacks,PlaceholderAPI,AdvancedChests,ShulkerPacks,CoreProtect]
 commands:
   sort:
     description: Toggle automatic chest sorting or change your hotkey settings


### PR DESCRIPTION
CoreProtect will log correctly when using Fill/Empty Chest hotkeys, I recorded a video to show this process.

https://imgur.com/a/HxQASe7

For older versions of CoreProtect, I read the [CoreProtect API Documentation](https://docs.coreprotect.net/api/) of API 7/8/9, It doesn't mention a change for the API method which logging container transactions. So I'm guessing older versions are supported, but I haven't tested.