### PR TITLE
Fix AutoSort GUI permission mismatch

### DIFF
--- a/src/main/java/de/jeff_media/chestsort/enums/Hotkey.java
+++ b/src/main/java/de/jeff_media/chestsort/enums/Hotkey.java
@@ -40,7 +40,7 @@ public enum Hotkey {
     public static String getPermission(Hotkey hotkey) {
 
         if(hotkey == AUTO_SORT) {
-            return "chestsort.use";
+            return "chestsort.automatic";
         }
 
         if(hotkey == AUTO_INV_SORT) {


### PR DESCRIPTION
Auto Sort was using chestsort.use. As a result, if any player had permission 'chestsort.automatic' set to false, they would still see the toggleable item in the GUI, instead of the nopermission barrier.